### PR TITLE
Removed command, query and event from IMediator contracts

### DIFF
--- a/src/SimpleSoft.Mediator.Abstractions/IMediator.cs
+++ b/src/SimpleSoft.Mediator.Abstractions/IMediator.cs
@@ -35,45 +35,37 @@ namespace SimpleSoft.Mediator
         /// <summary>
         /// Sends a command to an <see cref="ICommandHandler{TCommand}"/>.
         /// </summary>
-        /// <typeparam name="TCommand">The command type</typeparam>
         /// <param name="cmd">The command to publish</param>
         /// <param name="ct">The cancellation token</param>
         /// <returns>A task to be awaited</returns>
-        Task SendAsync<TCommand>(TCommand cmd, CancellationToken ct = default)
-            where TCommand : class, ICommand;
+        Task SendAsync(ICommand cmd, CancellationToken ct);
 
         /// <summary>
         /// Sends a command to an <see cref="ICommandHandler{TCommand,TResult}"/> and 
         /// returns the operation result.
         /// </summary>
-        /// <typeparam name="TCommand">The command type</typeparam>
         /// <typeparam name="TResult">The result type</typeparam>
         /// <param name="cmd">The command to publish</param>
         /// <param name="ct">The cancellation token</param>
         /// <returns>A task to be awaited for the result</returns>
-        Task<TResult> SendAsync<TCommand, TResult>(TCommand cmd, CancellationToken ct = default)
-            where TCommand : class, ICommand<TResult>;
+        Task<TResult> SendAsync<TResult>(ICommand<TResult> cmd, CancellationToken ct);
 
         /// <summary>
         /// Broadcast the event across all <see cref="IEventHandler{TEvent}"/>.
         /// </summary>
-        /// <typeparam name="TEvent">The event type</typeparam>
         /// <param name="evt">The event to broadcast</param>
         /// <param name="ct">The cancellation token</param>
         /// <returns>A task to be awaited</returns>
-        Task BroadcastAsync<TEvent>(TEvent evt, CancellationToken ct = default)
-            where TEvent : class, IEvent;
+        Task BroadcastAsync(IEvent evt, CancellationToken ct);
 
         /// <summary>
         /// Fetches a query from a <see cref="IQueryHandler{TQuery,TResult}"/> and 
         /// returns the query result.
         /// </summary>
-        /// <typeparam name="TQuery">The query type</typeparam>
         /// <typeparam name="TResult">The result type</typeparam>
         /// <param name="query">The query to fetch</param>
         /// <param name="ct">The cancellation token</param>
         /// <returns>A task to be awaited for the result</returns>
-        Task<TResult> FetchAsync<TQuery, TResult>(TQuery query, CancellationToken ct = default)
-            where TQuery : class, IQuery<TResult>;
+        Task<TResult> FetchAsync<TResult>(IQuery<TResult> query, CancellationToken ct);
     }
 }

--- a/src/SimpleSoft.Mediator.Abstractions/MediatorExtensions.cs
+++ b/src/SimpleSoft.Mediator.Abstractions/MediatorExtensions.cs
@@ -35,12 +35,10 @@ namespace SimpleSoft.Mediator
         /// <summary>
         /// Sends a command to an <see cref="ICommandHandler{TCommand}"/>.
         /// </summary>
-        /// <typeparam name="TCommand">The command type</typeparam>
         /// <param name="mediator">The mediator to use</param>
         /// <param name="cmd">The command to publish</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public static void Send<TCommand>(this IMediator mediator, TCommand cmd)
-            where TCommand : class, ICommand
+        public static void Send(this IMediator mediator, ICommand cmd)
         {
             if (mediator == null) throw new ArgumentNullException(nameof(mediator));
 
@@ -56,18 +54,16 @@ namespace SimpleSoft.Mediator
         /// Sends a command to an <see cref="ICommandHandler{TCommand,TResult}"/> and 
         /// returns the operation result.
         /// </summary>
-        /// <typeparam name="TCommand">The command type</typeparam>
         /// <typeparam name="TResult">The result type</typeparam>
         /// <param name="mediator">The mediator to use</param>
         /// <param name="cmd">The command to publish</param>
         /// <returns>The handler result</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static TResult Send<TCommand, TResult>(this IMediator mediator, TCommand cmd)
-            where TCommand : class, ICommand<TResult>
+        public static TResult Send<TResult>(this IMediator mediator, ICommand<TResult> cmd)
         {
             if (mediator == null) throw new ArgumentNullException(nameof(mediator));
 
-            return mediator.SendAsync<TCommand, TResult>(cmd, CancellationToken.None)
+            return mediator.SendAsync(cmd, CancellationToken.None)
 #if NET40
                 .Result;
 #else
@@ -78,12 +74,10 @@ namespace SimpleSoft.Mediator
         /// <summary>
         /// Broadcast the event across all <see cref="IEventHandler{TEvent}"/>.
         /// </summary>
-        /// <typeparam name="TEvent">The event type</typeparam>
         /// <param name="mediator">The mediator to use</param>
         /// <param name="evt">The event to broadcast</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public static void Broadcast<TEvent>(this IMediator mediator, TEvent evt)
-            where TEvent : class, IEvent
+        public static void Broadcast(this IMediator mediator, IEvent evt)
         {
             if (mediator == null) throw new ArgumentNullException(nameof(mediator));
 
@@ -99,18 +93,16 @@ namespace SimpleSoft.Mediator
         /// Fetches a query from a <see cref="IQueryHandler{TQuery,TResult}"/> and 
         /// returns the query result.
         /// </summary>
-        /// <typeparam name="TQuery">The query type</typeparam>
         /// <typeparam name="TResult">The result type</typeparam>
         /// <param name="mediator">The mediator to use</param>
         /// <param name="query">The query to fetch</param>
         /// <returns>The handler result</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static TResult Fetch<TQuery, TResult>(this IMediator mediator, TQuery query)
-            where TQuery : class, IQuery<TResult>
+        public static TResult Fetch<TResult>(this IMediator mediator, IQuery<TResult> query)
         {
             if (mediator == null) throw new ArgumentNullException(nameof(mediator));
 
-            return mediator.FetchAsync<TQuery, TResult>(query, CancellationToken.None)
+            return mediator.FetchAsync(query, CancellationToken.None)
 #if NET40
                 .Result;
 #else

--- a/src/SimpleSoft.Mediator.Microsoft.Extensions/MicrosoftMediator.cs
+++ b/src/SimpleSoft.Mediator.Microsoft.Extensions/MicrosoftMediator.cs
@@ -52,13 +52,12 @@ namespace SimpleSoft.Mediator
         }
 
         /// <inheritdoc />
-        public async Task SendAsync<TCommand>(TCommand cmd, CancellationToken ct = new CancellationToken()) 
-            where TCommand : class, ICommand
+        public async Task SendAsync(ICommand cmd, CancellationToken ct)
         {
             if (cmd == null) throw new ArgumentNullException(nameof(cmd));
 
             using (_logger.BeginScope(
-                "CommandName:{commandName} CommandId:{commandId}", typeof(TCommand).Name, cmd.Id))
+                "CommandName:{commandName} CommandId:{commandId}", cmd.GetType().Name, cmd.Id))
             {
                 _logger.LogDebug("Sending command");
                 await _mediator.SendAsync(cmd, ct).ConfigureAwait(false);
@@ -66,25 +65,23 @@ namespace SimpleSoft.Mediator
         }
 
         /// <inheritdoc />
-        public async Task<TResult> SendAsync<TCommand, TResult>(TCommand cmd, CancellationToken ct = new CancellationToken()) 
-            where TCommand : class, ICommand<TResult>
+        public async Task<TResult> SendAsync<TResult>(ICommand<TResult> cmd, CancellationToken ct)
         {
             using (_logger.BeginScope(
-                "CommandName:{commandName} CommandId:{commandId}", typeof(TCommand).Name, cmd.Id))
+                "CommandName:{commandName} CommandId:{commandId}", cmd.GetType().Name, cmd.Id))
             {
                 _logger.LogDebug("Sending command");
-                return await _mediator.SendAsync<TCommand, TResult>(cmd, ct).ConfigureAwait(false);
+                return await _mediator.SendAsync(cmd, ct).ConfigureAwait(false);
             }
         }
 
         /// <inheritdoc />
-        public async Task BroadcastAsync<TEvent>(TEvent evt, CancellationToken ct = new CancellationToken()) 
-            where TEvent : class, IEvent
+        public async Task BroadcastAsync(IEvent evt, CancellationToken ct)
         {
             if (evt == null) throw new ArgumentNullException(nameof(evt));
 
             using (_logger.BeginScope(
-                "EventName:{eventName} EventId:{eventId}", typeof(TEvent).Name, evt.Id))
+                "EventName:{eventName} EventId:{eventId}", evt.GetType().Name, evt.Id))
             {
                 _logger.LogDebug("Broadcasting event");
                 await _mediator.BroadcastAsync(evt, ct).ConfigureAwait(false);
@@ -92,16 +89,15 @@ namespace SimpleSoft.Mediator
         }
 
         /// <inheritdoc />
-        public async Task<TResult> FetchAsync<TQuery, TResult>(TQuery query, CancellationToken ct = new CancellationToken()) 
-            where TQuery : class, IQuery<TResult>
+        public async Task<TResult> FetchAsync<TResult>(IQuery<TResult> query, CancellationToken ct)
         {
             if (query == null) throw new ArgumentNullException(nameof(query));
 
             using (_logger.BeginScope(
-                "QueryName:{queryName} QueryId:{queryId}", typeof(TQuery).Name, query.Id))
+                "QueryName:{queryName} QueryId:{queryId}", query.GetType().Name, query.Id))
             {
                 _logger.LogDebug("Fetching query data");
-                return await _mediator.FetchAsync<TQuery, TResult>(query, ct).ConfigureAwait(false);
+                return await _mediator.FetchAsync(query, ct).ConfigureAwait(false);
             }
         }
     }

--- a/src/SimpleSoft.Mediator/SimpleSoft.Mediator.csproj
+++ b/src/SimpleSoft.Mediator/SimpleSoft.Mediator.csproj
@@ -4,7 +4,7 @@
 
 	<PropertyGroup>
 		<Description>Mediator implementation for commands and events.</Description>
-		<TargetFrameworks>netstandard2.0;netstandard1.0;net4.5;net4.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard1.1;net4.5;net4.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/SimpleSoft.Mediator.Tests/TMediator/MediatorTests.cs
+++ b/test/SimpleSoft.Mediator.Tests/TMediator/MediatorTests.cs
@@ -50,7 +50,7 @@ namespace SimpleSoft.Mediator.Tests.TMediator
 
             var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                await mediator.SendAsync<MockResultCommand, object>(null, CancellationToken.None);
+                await mediator.SendAsync<object>(null, CancellationToken.None);
             });
             Assert.NotNull(ex);
         }
@@ -64,7 +64,7 @@ namespace SimpleSoft.Mediator.Tests.TMediator
 
             var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                await mediator.BroadcastAsync<MockEvent>(null, CancellationToken.None);
+                await mediator.BroadcastAsync(null, CancellationToken.None);
             });
             Assert.NotNull(ex);
         }
@@ -103,7 +103,7 @@ namespace SimpleSoft.Mediator.Tests.TMediator
                     type => Enumerable.Empty<object>()),
                 new IPipeline[0]);
 
-            await mediator.SendAsync<MockResultCommand, object>(new MockResultCommand(), CancellationToken.None);
+            await mediator.SendAsync(new MockResultCommand(), CancellationToken.None);
             Assert.True(handlerFound);
         }
 

--- a/work/SimpleSoft.Mediator.Example.Api/Controllers/Products/ProductsController.cs
+++ b/work/SimpleSoft.Mediator.Example.Api/Controllers/Products/ProductsController.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using SimpleSoft.Mediator.Example.Api.Handlers;
 using SimpleSoft.Mediator.Example.Api.Handlers.Products;
 
 namespace SimpleSoft.Mediator.Example.Api.Controllers.Products
@@ -21,13 +20,12 @@ namespace SimpleSoft.Mediator.Example.Api.Controllers.Products
         [HttpGet]
         public async Task<PageModel<ProductModel>> SearchAsync([FromQuery] string filterQ, [FromQuery] int? skip, [FromQuery] int? take, CancellationToken ct)
         {
-            var result = await _mediator.FetchAsync<SearchProductsQuery, Page<Product>>(
-                new SearchProductsQuery(User.Identity)
-                {
-                    FilterQ = filterQ,
-                    Skip = skip,
-                    Take = take
-                }, ct);
+            var result = await _mediator.FetchAsync(new SearchProductsQuery(User.Identity)
+            {
+                FilterQ = filterQ,
+                Skip = skip,
+                Take = take
+            }, ct);
 
             return new PageModel<ProductModel>
             {
@@ -44,11 +42,10 @@ namespace SimpleSoft.Mediator.Example.Api.Controllers.Products
         [HttpGet("{id:guid}")]
         public async Task<ProductModel> GetByIdAsync([FromRoute] Guid id, CancellationToken ct)
         {
-            var result = await _mediator.FetchAsync<GetProductByIdQuery, Product>(
-                new GetProductByIdQuery(User.Identity)
-                {
-                    ProductId = id
-                }, ct);
+            var result = await _mediator.FetchAsync(new GetProductByIdQuery(User.Identity)
+            {
+                ProductId = id
+            }, ct);
 
             return new ProductModel
             {
@@ -61,12 +58,11 @@ namespace SimpleSoft.Mediator.Example.Api.Controllers.Products
         [HttpPost]
         public async Task<ProductModel> CreateAsync([FromBody] CreateProductModel model, CancellationToken ct)
         {
-            var result = await _mediator.SendAsync<CreateProductCommand, Product>(
-                new CreateProductCommand(User.Identity)
-                {
-                    Code = model.Code,
-                    Name = model.Name
-                }, ct);
+            var result = await _mediator.SendAsync(new CreateProductCommand(User.Identity)
+            {
+                Code = model.Code,
+                Name = model.Name
+            }, ct);
 
             return new ProductModel
             {

--- a/work/SimpleSoft.Mediator.Example.Cmd/Program.cs
+++ b/work/SimpleSoft.Mediator.Example.Cmd/Program.cs
@@ -107,10 +107,10 @@ namespace SimpleSoft.Mediator.Example.Cmd
 
             public async Task RunAsync(CancellationToken ct)
             {
-                var userId = await _mediator.SendAsync<CreateUserCommand, Guid>(
+                var userId = await _mediator.SendAsync(
                     new CreateUserCommand("john.doe@email.com", "John Doe"), ct);
 
-                var user = await _mediator.FetchAsync<UserByIdQuery, User>(
+                var user = await _mediator.FetchAsync(
                     new UserByIdQuery(userId), ct);
 
                 await _mediator.SendAsync(


### PR DESCRIPTION
Simplified the usage of `IMediator` interface by ensuring commands, queries and events can be automatically inferred from parameters.